### PR TITLE
Add a logrotator for drupal_syslog

### DIFF
--- a/drupal_syslog
+++ b/drupal_syslog
@@ -1,0 +1,8 @@
+/var/log/drupal.log {
+copytruncate
+daily
+rotate 7
+compress
+missingok
+size 1k
+}

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
-sudo cp islandora_logrotate /etc/logrotate.d/islandora_logrotate
-sudo chmod 644 /etc/logrotate.d/islandora_logrotate
+sudo cp islandora_logrotate drupal_syslog /etc/logrotate.d/islandora_logrotate
+sudo chmod 644 /etc/logrotate.d/islandora_logrotate /etc/logrotate.d/drupal_syslog

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,2 @@
-sudo cp islandora_logrotate drupal_syslog /etc/logrotate.d/islandora_logrotate
+sudo cp islandora_logrotate drupal_syslog /etc/logrotate.d/
 sudo chmod 644 /etc/logrotate.d/islandora_logrotate /etc/logrotate.d/drupal_syslog


### PR DESCRIPTION
This assumes that you used the suggested default drupal log name of
/var/log/drupal.log
