### PR TITLE
Add su directive

### DIFF
--- a/islandora_logrotate
+++ b/islandora_logrotate
@@ -5,6 +5,7 @@ rotate 14
 compress
 missingok
 size 1k
+su fedora fedora
 }
 /usr/local/fedora/tomcat/logs/*.log {
 copytruncate
@@ -13,6 +14,7 @@ rotate 14
 compress
 missingok
 size 1k
+su fedora fedora
 }
 /usr/local/fedora/server/logs/*.log {
 copytruncate
@@ -21,4 +23,5 @@ rotate 14
 compress
 missingok
 size 1k
+su fedora fedora
 }


### PR DESCRIPTION
logrotate complains if the directories where it is rotating logs are not
secure. Example error:

error: skipping "/usr/local/fedora/tomcat/logs/mylogfile.log" because parent
       directory has insecure permissions (It's world writable or writable by
       group which is not "root") Set "su" directive in config file to tell
       logrotate which user/group should be used for rotation.

This small change will make logrotate work.